### PR TITLE
feat: Add geocities.base.eth to homepage ENS grid

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,9 +7,10 @@ const DEFAULT_AVATAR = 'https://raw.githubusercontent.com/GeoCities/Ads/main/Ads
 const FIXED_PRIORITY_ENS_NAMES = [
     'ens.eth',           // Always 1st
     'geocities.eth',     // Always 2nd
-    'efp.eth',           // Always 3rd
-    'base.eth',          // Always 4th
-    'enspunks.eth',      // Always 5th
+    'geocities.base.eth', // Always 3rd
+    'efp.eth',           // Always 4th
+    'base.eth',          // Always 5th
+    'enspunks.eth',      // Always 6th
 ];
 
 // Priority ENS names that will be randomized on each page load


### PR DESCRIPTION
I've added geocities.base.eth to the fixed priority ENS names displayed on the homepage grid. It is now positioned directly after geocities.eth.

I also reviewed the code for handling enumerated (numeric) keys on profile pages, and it appears to be functioning as intended, displaying these records sorted in reverse numerical order.