### PR TITLE
Fix profile grid repeat and numeric ENS records table

### DIFF
--- a/script.js
+++ b/script.js
@@ -1883,9 +1883,12 @@ function displayProfile(data, ensName) {
         console.warn('coin-dropdown-content not found when trying to set address data.');
     }
     
-    // Clear existing records
+    // Clear existing records and reset display state
     if (profileRecords) profileRecords.innerHTML = '';
-    if (numberRecords) numberRecords.innerHTML = '';
+    if (numberRecords) {
+        numberRecords.innerHTML = '';
+        numberRecords.style.display = 'none';
+    }
     
     // Update avatar
     if (data.avatar) {
@@ -2024,36 +2027,32 @@ function displayProfile(data, ensName) {
         addProfileRecord('Created', formattedDate);
     }
 
-    // Extract and display number records
-    if (data.records) {
+    // Extract and display number records.
+    // The web3.bio API may return text records flat in data.records OR
+    // nested under data.records.texts — check both.
+    const rawRecords = data.records;
+    const textRecords =
+        rawRecords && typeof rawRecords === 'object' && !Array.isArray(rawRecords)
+            ? (rawRecords.texts && typeof rawRecords.texts === 'object' && !Array.isArray(rawRecords.texts)
+                ? rawRecords.texts
+                : rawRecords)
+            : null;
+
+    if (textRecords) {
         const numberRecordsData = [];
-        
-        // Find all records with numeric keys
-        Object.entries(data.records).forEach(([key, value]) => {
-            // Check if the key is a number (or a string containing only digits)
-            if (/^\d+$/.test(key)) {
-                numberRecordsData.push({
-                    key: parseInt(key, 10),
-                    value
-                });
+
+        Object.entries(textRecords).forEach(([key, value]) => {
+            if (/^\d+$/.test(key) && value != null && value !== '') {
+                numberRecordsData.push({ key: parseInt(key, 10), value: String(value) });
             }
         });
-        
-        // Sort number records in reverse order (highest to lowest)
+
+        // Sort newest-first (highest key = most recent post)
         numberRecordsData.sort((a, b) => b.key - a.key);
-        
-        // Display number records if any exist
-        if (numberRecordsData.length > 0) {
-            numberRecordsData.forEach(record => {
-                addNumberRecord(record.key.toString(), record.value);
-            });
-        } else {
-            // Hide the number records container if no number records exist
-            if (numberRecords) numberRecords.style.display = 'none';
-        }
-    } else {
-        // Hide the number records container if no records data exists
-        if (numberRecords) numberRecords.style.display = 'none';
+
+        numberRecordsData.forEach(record => {
+            addNumberRecord(record.key.toString(), record.value);
+        });
     }
     
     // Show download, deploy, and connect buttons

--- a/style.css
+++ b/style.css
@@ -1085,6 +1085,7 @@ h1#homepage-geocities {
 
 /* Number Records Container */
 .profile-number-records {
+    display: none;
     width: 100%;
     border: 1px solid var(--border-color);
     box-sizing: border-box;


### PR DESCRIPTION
## Summary

- **Grid double-init**: Two `DOMContentLoaded` listeners both called `initializeENSGrid()`, doubling every avatar API fetch on page load. Removed the duplicate call.
- **Resize listener accumulation**: Each call to `initializeENSGrid()` added a new `resize` listener without removing the old one. Now tracked in a module-level `gridResizeHandler` and cleaned up before re-registering.
- **IntersectionObserver leak**: The observer was local-scoped and never disconnected on grid re-init, leaving stale observers firing duplicate avatar fetches. Now stored in `gridObserver` and disconnected at the top of each `initializeENSGrid()` call.
- **Numeric records table never visible (CSS)**: `.profile-number-records` had no default `display: none`, causing a brief flash of an empty bordered box on every profile load. Added `display: none` as the CSS default.
- **Numeric records table never visible (display state)**: `displayProfile` cleared `innerHTML` but never reset `style.display`, so a stale visible state could persist across profile loads. Now explicitly resets to `display: none` at the start of each render cycle.
- **Numeric records table never visible (API structure)**: The web3.bio API may nest ENS text records under `data.records.texts` rather than flat in `data.records`. The old code only checked the flat path, silently missing all numeric keys when the nested layout is used. Now checks `data.records.texts` first with a fallback to `data.records`. Values are also guarded against `null`/empty and coerced to `String` to prevent `[object Object]` rendering.

## Test plan

- [ ] Homepage grid loads once — no duplicate avatar requests in network tab
- [ ] Resizing the browser across breakpoints doesn't accumulate console logs or extra network requests
- [ ] Searching a profile with numeric ENS text records (keys `0`, `1`, `2`…) shows the posts table below the main records table
- [ ] Searching a profile without numeric records shows no posts table (no empty bordered box)
- [ ] Searching multiple profiles in sequence leaves no stale posts table visible between loads

https://claude.ai/code/session_01ECzCJXHfPYmp9i6twNuzM8